### PR TITLE
fix: read version from package.json

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -53,10 +53,14 @@ function getUpdateHighlight(current, latest) {
 
 const program = new Command();
 
+// Read version from package.json
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'));
+
 program
   .name('pr-vibe')
   .description('AI-powered PR review responder that vibes with bots')
-  .version('0.2.1');
+  .version(pkg.version);
 
 program
   .command('pr <number>')


### PR DESCRIPTION
Quick fix to read version dynamically from package.json instead of hardcoding it in the CLI. This prevents version mismatches.