### PR TITLE
chore: release v0.4.1 - fix CLI changelog version

### DIFF
--- a/.github/workflows/publish-current.yml
+++ b/.github/workflows/publish-current.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Run tests
         run: npm test
         
+      - name: Update changelog version in CLI
+        run: node scripts/update-changelog-version.js
+        
       - name: Publish to npm
         run: npm publish --access public
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run tests
         run: npm test
         
+      - name: Update changelog version in CLI
+        run: node scripts/update-changelog-version.js
+        
       - name: Check if version needs bump
         id: version_check
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to pr-vibe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-06-19
+
+### 🐛 Fixed
+- **CLI Changelog Command** - Updated hardcoded version from 0.2.0 to current version
+  - The `pr-vibe changelog` command now correctly shows v0.4.0 as the current version
+  - Added automated changelog version updates to CI/CD pipeline
+  - Future releases will automatically update the CLI changelog
+
+### 🔧 Improved
+- **Release Process** - Added automated changelog version synchronization
+  - Created `scripts/update-changelog-version.js` to sync CLI with package.json version
+  - Updated GitHub Actions workflows to run changelog update during releases
+  - Ensures users always see the correct version information
+
+## [0.4.0] - 2025-06-18
+
+### ✨ Added
+- **Comprehensive Reporting System** - Detailed decision logs for every PR review
+  - ReportBuilder generates structured reports with bot comments, decisions, and actions
+  - Reports saved in `.pr-bot/reports/` in both Markdown and JSON formats
+  - Automatic TTL management (30-day retention by default)
+  
+- **Pre-Merge Safety Commands** - New commands to ensure PR readiness
+  - `pr-vibe check <pr>` - Exit code 0/1 for CI integration
+  - `pr-vibe status <pr>` - View or post GitHub status checks
+  - `pr-vibe report <pr>` - Access saved reports
+  - `pr-vibe cleanup` - Remove old reports
+
+### 🐛 Fixed
+- **Critical File Replacement Bug** - pr-vibe no longer replaces files with TODO placeholders
+  - Fixed decision-engine.js to return null instead of TODO strings
+  - Added safety checks in file-modifier.js
+  - Prevents accidental file corruption
+
 ## [0.3.4] - 2025-06-18
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,11 @@ Created comprehensive tracking in `.internal-docs/`:
 - **Release Process**: 
   1. Create release branch: `git checkout -b release/vX.Y.Z`
   2. Bump version in package.json
-  3. Create PR and merge
-  4. Create GitHub Release: `gh release create vX.Y.Z`
-  5. This triggers automatic npm publish via GitHub Actions
+  3. Update CHANGELOG.md with release notes
+  4. Run `node scripts/update-changelog-version.js` (or let CI do it)
+  5. Create PR and merge
+  6. Create GitHub Release: `gh release create vX.Y.Z`
+  7. This triggers automatic npm publish via GitHub Actions (including changelog update)
 
 ## v0.4.0 Release (2025-06-18)
 **Major Features**: Comprehensive reporting and pre-merge safety
@@ -197,6 +199,7 @@ Using pr-vibe on its own PRs proved invaluable - CodeRabbit caught a critical se
 3. **ALWAYS run pr-vibe check before merging** - Ensures all bot comments resolved
 4. **ALWAYS use GitHub releases for npm publish** - Never publish locally
 5. **ALWAYS verify tests pass** - GitHub Actions must be green
+6. **ALWAYS update changelog** - Either run `node scripts/update-changelog-version.js` or let CI handle it
 
 ## Next Session Priorities
 1. Verify ProductHunt launch is actually submitted/scheduled

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -48,7 +48,11 @@ function getUpdateHighlight(current, latest) {
     return 'Major update with new features!';
   } else if (latestMinor > currMinor) {
     // Specific highlights for known versions
-    if (latest.startsWith('0.2')) {
+    if (latest.startsWith('0.4')) {
+      return 'Comprehensive reporting and pre-merge safety checks';
+    } else if (latest.startsWith('0.3')) {
+      return 'Conversation management and security fixes';
+    } else if (latest.startsWith('0.2')) {
       return 'Human review support with --include-human-reviews flag';
     }
     return 'New features and improvements';
@@ -601,17 +605,27 @@ program
       }
     } else {
       // Show recent highlights
-      console.log(chalk.cyan('## Version 0.2.0 (Current)'));
+      console.log(chalk.cyan('## Version 0.4.1 (Current)'));
+      console.log('  🐛 Fixed CLI changelog showing outdated version');
+      console.log('  🔧 Automated changelog version updates in CI/CD\n');
+      
+      console.log(chalk.cyan('## Version 0.4.0'));
+      console.log('  📊 Comprehensive reporting with decision logs');
+      console.log('  🛡️ Pre-merge safety checks (check, status, report commands)');
+      console.log('  📝 Persistent report storage with 30-day TTL');
+      console.log('  🐛 Fixed critical file replacement bug\n');
+      
+      console.log(chalk.cyan('## Version 0.3.x'));
+      console.log('  🤝 Full conversation management with bots');
+      console.log('  🔒 Security fix for shell injection vulnerability');
+      console.log('  📏 GitHub comment length handling');
+      console.log('  🎯 Zero-setup demo experience\n');
+      
+      console.log(chalk.cyan('## Version 0.2.0'));
       console.log('  ✨ Human review support with --include-human-reviews flag');
       console.log('  🔔 Automatic update notifications');
       console.log('  🐛 Case-insensitive bot detection');
       console.log('  📊 Pattern learning from team feedback\n');
-      
-      console.log(chalk.cyan('## Version 0.1.2 (Previous)'));
-      console.log('  🚀 Initial public release');
-      console.log('  🤖 CodeRabbit and DeepSource support');
-      console.log('  🧠 Pattern learning system');
-      console.log('  ⚡ Auto-fix common issues\n');
       
       console.log(chalk.gray('Run with --full to see complete changelog'));
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-vibe",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AI-powered PR review responder that vibes with CodeRabbit, DeepSource, and other bots to automate repetitive feedback",
   "keywords": [
     "ai",

--- a/scripts/update-changelog-version.js
+++ b/scripts/update-changelog-version.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Read current version from package.json
+const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'));
+const currentVersion = pkg.version;
+const [major, minor, patch] = currentVersion.split('.').map(Number);
+
+console.log(`Updating changelog in CLI to version ${currentVersion}...`);
+
+// Read cli.js
+const cliPath = join(rootDir, 'bin', 'cli.js');
+let cliContent = readFileSync(cliPath, 'utf-8');
+
+// Update the changelog command section
+// Find the changelog section
+const changelogStart = cliContent.indexOf("console.log(chalk.cyan('## Version");
+if (changelogStart === -1) {
+  console.error('Could not find changelog section in cli.js');
+  process.exit(1);
+}
+
+// Extract current changelog section
+const changelogEnd = cliContent.indexOf('console.log(chalk.gray(\'Run with --full', changelogStart);
+const oldChangelog = cliContent.substring(changelogStart, changelogEnd);
+
+// Build new changelog based on current version
+let newChangelog = `      console.log(chalk.cyan('## Version ${currentVersion} (Current)'));\n`;
+
+// Add version-specific features
+if (major === 0 && minor === 4) {
+  newChangelog += `      console.log('  📊 Comprehensive reporting with decision logs');\n`;
+  newChangelog += `      console.log('  🛡️ Pre-merge safety checks (check, status, report commands)');\n`;
+  newChangelog += `      console.log('  📝 Persistent report storage with 30-day TTL');\n`;
+  newChangelog += `      console.log('  🐛 Fixed critical file replacement bug\\n');\n`;
+} else if (major === 0 && minor === 3) {
+  newChangelog += `      console.log('  🤝 Full conversation management with bots');\n`;
+  newChangelog += `      console.log('  🔒 Security fix for shell injection vulnerability');\n`;
+  newChangelog += `      console.log('  📏 GitHub comment length handling');\n`;
+  newChangelog += `      console.log('  🎯 Zero-setup demo experience\\n');\n`;
+} else if (major === 0 && minor === 2) {
+  newChangelog += `      console.log('  ✨ Human review support with --include-human-reviews flag');\n`;
+  newChangelog += `      console.log('  🔔 Automatic update notifications');\n`;
+  newChangelog += `      console.log('  🐛 Case-insensitive bot detection');\n`;
+  newChangelog += `      console.log('  📊 Pattern learning from team feedback\\n');\n`;
+} else {
+  // Generic features for unknown versions
+  newChangelog += `      console.log('  ✨ New features and improvements');\n`;
+  newChangelog += `      console.log('  🐛 Bug fixes and enhancements\\n');\n`;
+}
+
+// Add previous versions (always show at least 2 previous minor versions)
+newChangelog += `      \n`;
+
+// Add previous versions based on current
+if (major === 0 && minor >= 4) {
+  newChangelog += `      console.log(chalk.cyan('## Version 0.3.x'));\n`;
+  newChangelog += `      console.log('  🤝 Full conversation management with bots');\n`;
+  newChangelog += `      console.log('  🔒 Security fix for shell injection vulnerability');\n`;
+  newChangelog += `      console.log('  📏 GitHub comment length handling');\n`;
+  newChangelog += `      console.log('  🎯 Zero-setup demo experience\\n');\n`;
+  newChangelog += `      \n`;
+  newChangelog += `      console.log(chalk.cyan('## Version 0.2.0'));\n`;
+  newChangelog += `      console.log('  ✨ Human review support with --include-human-reviews flag');\n`;
+  newChangelog += `      console.log('  🔔 Automatic update notifications');\n`;
+  newChangelog += `      console.log('  🐛 Case-insensitive bot detection');\n`;
+  newChangelog += `      console.log('  📊 Pattern learning from team feedback\\n');\n`;
+} else if (major === 0 && minor === 3) {
+  newChangelog += `      console.log(chalk.cyan('## Version 0.2.0'));\n`;
+  newChangelog += `      console.log('  ✨ Human review support with --include-human-reviews flag');\n`;
+  newChangelog += `      console.log('  🔔 Automatic update notifications');\n`;
+  newChangelog += `      console.log('  🐛 Case-insensitive bot detection');\n`;
+  newChangelog += `      console.log('  📊 Pattern learning from team feedback\\n');\n`;
+  newChangelog += `      \n`;
+  newChangelog += `      console.log(chalk.cyan('## Version 0.1.2'));\n`;
+  newChangelog += `      console.log('  🚀 Initial public release');\n`;
+  newChangelog += `      console.log('  🤖 CodeRabbit and DeepSource support');\n`;
+  newChangelog += `      console.log('  🧠 Pattern learning system');\n`;
+  newChangelog += `      console.log('  ⚡ Auto-fix common issues\\n');\n`;
+}
+
+newChangelog += `      \n`;
+
+// Replace the old changelog with new
+cliContent = cliContent.substring(0, changelogStart) + newChangelog + cliContent.substring(changelogEnd);
+
+// Also update the version hint function
+const versionHintPattern = /if \(latest\.startsWith\('0\.\d+'\)\) \{[\s\S]*?return '[^']+';[\s\S]*?\}/g;
+const versionHints = [];
+
+// Add hints for known versions
+if (minor >= 4) {
+  versionHints.push(`    if (latest.startsWith('0.4')) {\n      return 'Comprehensive reporting and pre-merge safety checks';\n    }`);
+}
+if (minor >= 3) {
+  versionHints.push(`    if (latest.startsWith('0.3')) {\n      return 'Conversation management and security fixes';\n    }`);
+}
+if (minor >= 2) {
+  versionHints.push(`    if (latest.startsWith('0.2')) {\n      return 'Human review support with --include-human-reviews flag';\n    }`);
+}
+
+// Find and update the version hints section
+const hintSectionMatch = cliContent.match(/\/\/ Specific highlights for known versions[\s\S]*?return 'New features and improvements';/);
+if (hintSectionMatch) {
+  const newHintSection = `// Specific highlights for known versions\n${versionHints.map(hint => '    ' + hint.trim()).join(' else ')}\n    return 'New features and improvements';`;
+  cliContent = cliContent.replace(hintSectionMatch[0], newHintSection);
+}
+
+// Write updated content
+writeFileSync(cliPath, cliContent);
+
+console.log(`✅ Updated changelog in CLI to version ${currentVersion}`);
+
+// Make the script executable
+import { chmodSync } from 'fs';
+try {
+  chmodSync(__filename, '755');
+} catch (e) {
+  // Ignore chmod errors on Windows
+}


### PR DESCRIPTION
## Summary
- Fix CLI changelog command showing outdated version (0.2.0 instead of current)
- Add automated changelog version updates to CI/CD pipeline
- Ensure future releases automatically update the CLI changelog

## Changes
- Updated hardcoded changelog in `bin/cli.js` to show v0.4.1 as current
- Created `scripts/update-changelog-version.js` to automate version sync
- Updated GitHub Actions workflows to run changelog update during releases
- Added release process documentation in CLAUDE.md

## Test plan
- [ ] Run `pr-vibe changelog` to verify it shows v0.4.1 as current
- [ ] Check that GitHub Actions workflows include the changelog update step
- [ ] Verify the update script works: `node scripts/update-changelog-version.js`

🤖 Generated with [Claude Code](https://claude.ai/code)